### PR TITLE
修复 Docker 构建下表单校验器类型不兼容

### DIFF
--- a/app/(admin)/admin/settings/page.tsx
+++ b/app/(admin)/admin/settings/page.tsx
@@ -190,8 +190,9 @@ const settingsFormSchema = z.object({
   }),
 });
 
-type SettingsFormValues = z.infer<typeof settingsFormSchema>;
-type FieldPath = Path<SettingsFormValues>;
+type SettingsFormInput = z.input<typeof settingsFormSchema>;
+type SettingsFormValues = z.output<typeof settingsFormSchema>;
+type FieldPath = Path<SettingsFormInput>;
 
 const toLines = (value: string) =>
   value
@@ -286,7 +287,7 @@ export default function AdminSettingsPage() {
     control,
     register,
     reset,
-  } = useForm<SettingsFormValues>({
+  } = useForm<SettingsFormInput, unknown, SettingsFormValues>({
     resolver: zodResolver(settingsFormSchema),
     values: fallbackValues,
   });

--- a/components/auth/auth-form.tsx
+++ b/components/auth/auth-form.tsx
@@ -82,6 +82,9 @@ const registerFormSchema = loginFormSchema.extend({
   name: z.string().trim().min(1, "请输入昵称。"),
 });
 
+type AuthFormInput =
+  | z.input<typeof loginFormSchema>
+  | z.input<typeof registerFormSchema>;
 type AuthFormValues = z.output<typeof registerFormSchema>;
 
 export function AuthForm({ githubEnabled, mode, redirectTo }: AuthFormProps) {
@@ -93,7 +96,7 @@ export function AuthForm({ githubEnabled, mode, redirectTo }: AuthFormProps) {
   const [isEmailLoading, setIsEmailLoading] = useState(false);
   const [isGithubLoading, setIsGithubLoading] = useState(false);
   const resetSubmissionClock = () => setStartedAt(Date.now());
-  const form = useForm<AuthFormValues>({
+  const form = useForm<AuthFormInput, unknown, AuthFormValues>({
     defaultValues: {
       email: "",
       name: "",


### PR DESCRIPTION
## Summary
- 将后台设置页和登录/注册表单的 `react-hook-form` 泛型拆分为输入类型与输出类型，避免 `zodResolver` 在 clean install 环境下出现类型不匹配。
- 保留 Zod schema 的默认值和服务端兜底逻辑，不调整 Dockerfile、CI workflow 或依赖版本。

## Testing
- `bun run lint` 通过。
- `bun run format:check` 通过。
- `bun run build` 通过。
- Docker builder clean build 通过，确认镜像构建不再被表单类型检查阻断。